### PR TITLE
[GEAR-446] Fix metadata overflow issue

### DIFF
--- a/frontend/components/example/DocumentList.vue
+++ b/frontend/components/example/DocumentList.vue
@@ -1,80 +1,120 @@
 <template>
-  <v-data-table
-    :value="value"
-    :headers="headers"
-    :items="items"
-    :options.sync="options"
-    :server-items-length="total"
-    :search="search"
-    :loading="isLoading"
-    :loading-text="$t('generic.loading')"
-    :no-data-text="$t('vuetify.noDataAvailable')"
-    :footer-props="{
-      showFirstLastPage: true,
-      'items-per-page-options': [10, 50, 100],
-      'items-per-page-text': $t('vuetify.itemsPerPageText'),
-      'page-text': $t('dataset.pageText')
-    }"
-    item-key="id"
-    show-select
-    @input="$emit('input', $event)"
-  >
-    <template #top>
-      <v-text-field
-        v-model="search"
-        :prepend-inner-icon="mdiMagnify"
-        :label="$t('generic.search') + ' (e.g. label:positive)'"
-        single-line
-        hide-details
-        filled
-      />
-    </template>
-    <template #[`item.isConfirmed`]="{ item }">
-      <v-chip :color="item.isConfirmed ? 'success' : 'warning'" text small>
-        {{ item.isConfirmed ? 'Finished' : 'In progress' }}
-      </v-chip>
-    </template>
-    <template #[`item.text`]="{ item }">
-      <span class="d-flex d-sm-none">{{ item.text | truncate(50) }}</span>
-      <span class="d-none d-sm-flex">{{ item.text | truncate(200) }}</span>
-    </template>
-    <template #[`item.meta`]="{ item }">
-      {{ JSON.stringify(item.meta, null, 4) }}
-    </template>
-    <template #[`item.assignee`]="{ item }">
-      <v-combobox
-        :value="toSelected(item)"
-        :items="members"
-        item-text="username"
-        no-data-text="No one"
-        multiple
-        chips
-        dense
-        flat
-        hide-selected
-        hide-details
-        small-chips
-        solo
-        style="width: 200px"
-        @change="onAssignOrUnassign(item, $event)"
-      >
-        <template #selection="{ attrs, item, parent, selected }">
-          <v-chip v-bind="attrs" :input-value="selected" small class="mt-1 mb-1">
-            <span class="pr-1">{{ item.username }}</span>
-            <v-icon small @click="parent.selectItem(item)"> $delete </v-icon>
-          </v-chip>
-        </template>
-      </v-combobox>
-    </template>
-    <template #[`item.action`]="{ item }">
-      <v-btn class="me-1" small color="primary text-capitalize" @click="$emit('edit', item)"
-        >Edit</v-btn
-      >
-      <v-btn small color="primary text-capitalize" @click="toLabeling(item)">
-        {{ $t('dataset.annotate') }}
-      </v-btn>
-    </template>
-  </v-data-table>
+  <div>
+    <v-data-table
+      :value="value"
+      :headers="headers"
+      :items="items"
+      :options.sync="options"
+      :server-items-length="total"
+      :search="search"
+      :loading="isLoading"
+      :loading-text="$t('generic.loading')"
+      :no-data-text="$t('vuetify.noDataAvailable')"
+      :footer-props="{
+        showFirstLastPage: true,
+        'items-per-page-options': [10, 50, 100],
+        'items-per-page-text': $t('vuetify.itemsPerPageText'),
+        'page-text': $t('dataset.pageText')
+      }"
+      item-key="id"
+      show-select
+      @input="$emit('input', $event)"
+    >
+      <template #top>
+        <v-text-field
+          v-model="search"
+          :prepend-inner-icon="mdiMagnify"
+          :label="$t('generic.search') + ' (e.g. label:positive)'"
+          single-line
+          hide-details
+          filled
+        />
+      </template>
+      <template #[`item.isConfirmed`]="{ item }">
+        <v-chip :color="item.isConfirmed ? 'success' : 'warning'" text small>
+          {{ item.isConfirmed ? 'Finished' : 'In progress' }}
+        </v-chip>
+      </template>
+      <template #[`item.text`]="{ item }">
+        <span class="document-text d-flex">{{ item.text | truncate(200) }}</span>
+      </template>
+      <template #[`item.meta`]="{ item }">
+        <div class="document-text d-flex flex-column">
+          <span class="d-none d-sm-flex">
+            {{ JSON.stringify(item.meta, null, 4) | truncate(200) }}
+          </span>
+          <template v-if="JSON.stringify(item.meta, null, 4).length >= 200">
+            <v-btn
+              class="text-none"
+              color="primary"
+              text
+              small
+              @click.stop="openSeeFullTextDialog(item.meta)"
+            >
+              See more
+            </v-btn>
+          </template>
+        </div>
+      </template>
+      <template #[`item.assignee`]="{ item }">
+        <v-combobox
+          :value="toSelected(item)"
+          :items="members"
+          item-text="username"
+          no-data-text="No one"
+          multiple
+          chips
+          dense
+          flat
+          hide-selected
+          hide-details
+          small-chips
+          solo
+          background-color="#0000000f"
+          style="width: 200px"
+          @change="onAssignOrUnassign(item, $event)"
+        >
+          <template #selection="{ attrs, item, parent, selected }">
+            <v-chip v-bind="attrs" :input-value="selected" small class="mt-1 mb-1">
+              <span class="pr-1">{{ item.username }}</span>
+              <v-icon small @click="parent.selectItem(item)"> $delete </v-icon>
+            </v-chip>
+          </template>
+        </v-combobox>
+      </template>
+      <template #[`item.action`]="{ item }">
+        <v-btn class="me-1" small color="primary text-capitalize" @click="$emit('edit', item)"
+          >Edit</v-btn
+        >
+        <v-btn small color="primary text-capitalize" @click="toLabeling(item)">
+          {{ $t('dataset.annotate') }}
+        </v-btn>
+      </template>
+    </v-data-table>
+    <v-dialog
+      v-model="dialog"
+      width="500"
+    >
+      <v-card>
+        <v-card-title class="text-h5">
+        </v-card-title>
+        <v-card-text>
+          {{ dialogText }}
+        </v-card-text>
+        <v-divider></v-divider>
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn
+            color="primary"
+            text
+            @click="dialog = false"
+          >
+            Close
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+  </div>
 </template>
 
 <script lang="ts">
@@ -120,6 +160,8 @@ export default Vue.extend({
 
   data() {
     return {
+      dialog: false,
+      dialogText: '',
       search: this.$route.query.q,
       options: {} as DataOptions,
       mdiMagnify
@@ -187,6 +229,10 @@ export default Vue.extend({
   },
 
   methods: {
+    openSeeFullTextDialog(text: string) {
+      this.dialog = true;
+      this.dialogText = text;
+    },
     toLabeling(item: ExampleDTO) {
       const index = this.items.indexOf(item)
       const offset = (this.options.page - 1) * this.options.itemsPerPage
@@ -221,3 +267,9 @@ export default Vue.extend({
   }
 })
 </script>
+
+<style scoped>
+.document-text {
+  padding: 16px;
+}
+</style>


### PR DESCRIPTION
* Add text clamping to metadata and add "See more" button to display full metadata text

<img width="1259" alt="Screenshot 2025-03-20 at 10 22 12 AM" src="https://github.com/user-attachments/assets/aef23b49-c6a4-4f71-a242-e1d8a9a1205e" />
