### PR TITLE
[GEAR-446] pt 2: fix Doccano label menu autocomplete

### DIFF
--- a/frontend/components/example/DocumentList.vue
+++ b/frontend/components/example/DocumentList.vue
@@ -36,12 +36,16 @@
         </v-chip>
       </template>
       <template #[`item.text`]="{ item }">
-        <span class="document-text d-flex">{{ item.text | truncate(200) }}</span>
+        <span class="d-none d-sm-flex document-text">{{ item.text | truncate(200) }}</span>
+        <span class="d-flex d-sm-none document-text">{{ item.text | truncate(50) }}</span>
       </template>
       <template #[`item.meta`]="{ item }">
-        <div class="document-text d-flex flex-column">
+        <div class="d-flex flex-column document-text">
           <span class="d-none d-sm-flex">
             {{ JSON.stringify(item.meta, null, 4) | truncate(200) }}
+          </span>
+          <span class="d-flex d-sm-none">
+            {{ JSON.stringify(item.meta, null, 4) | truncate(50) }}
           </span>
           <template v-if="JSON.stringify(item.meta, null, 4).length >= 200">
             <v-btn

--- a/frontend/components/tasks/sequenceLabeling/EntityEditor.vue
+++ b/frontend/components/tasks/sequenceLabeling/EntityEditor.vue
@@ -19,6 +19,7 @@
       @contextmenu:relation="deleteRelation"
     />
     <labeling-menu
+      v-if="entityMenuOpened"
       :opened="entityMenuOpened"
       :x="x"
       :y="y"
@@ -28,6 +29,7 @@
       @click:label="addOrUpdateEntity"
     />
     <labeling-menu
+      v-if="relationMenuOpened"
       :opened="relationMenuOpened"
       :x="x"
       :y="y"


### PR DESCRIPTION
## Bug fixes

* Fix Doccano label menu autocomplete selection when adding multiple annotations of the same label (e.g. age) consecutively
* Add back responsive text to document list